### PR TITLE
Add streaming support

### DIFF
--- a/c_src/ezstd_nif.cc
+++ b/c_src/ezstd_nif.cc
@@ -5,14 +5,21 @@
 #include <stdlib.h>
 #include <memory>
 #include <zstd.h>
+#include <string.h>
+
+#define MAX_BUFFER_SIZE (1<<30)
 
 const char kAtomError[] = "error";
 const char kAtomBadArg[] = "badarg";
+const char kAtomOk[] = "ok";
+const char kAtomContinue[] = "continue";
 
 atoms ATOMS;
 
 ErlNifResourceType *COMPRESS_DICTIONARY_RES_TYPE;
 ErlNifResourceType *DECOMPRESS_DICTIONARY_RES_TYPE;
+ErlNifResourceType *COMPRESS_CONTEXT_RES_TYPE;
+ErlNifResourceType *DECOMPRESS_CONTEXT_RES_TYPE;
 
 struct ZSTDCCtxDeleter {
   void operator()(ZSTD_CCtx* ctx) {
@@ -24,6 +31,16 @@ struct ZSTDDCtxDeleter {
   void operator()(ZSTD_DCtx* ctx) {
     ZSTD_freeDCtx(ctx);
   }
+};
+
+struct ZstdCCtxWithBuffer {
+    ZSTD_CCtx* cctx;
+    ZSTD_outBuffer out;
+};
+
+struct ZstdDCtxWithBuffer {
+    ZSTD_DCtx* dctx;
+    ZSTD_outBuffer out;
 };
 
 void zstd_nif_compress_dictionary_destructor(ErlNifEnv *env, void *res) {
@@ -38,18 +55,37 @@ void zstd_nif_decompress_dictionary_destructor(ErlNifEnv *env, void *res) {
   ZSTD_freeDDict(*dict_resource);
 }
 
+void zstd_nif_compression_context_destructor(ErlNifEnv *env, void *res) {
+    UNUSED(env);
+    ZstdCCtxWithBuffer* ctx_resource = static_cast<ZstdCCtxWithBuffer*>(res);
+    ZSTD_freeCCtx(ctx_resource->cctx);
+    free(ctx_resource->out.dst);
+}
+
+void zstd_nif_decompression_context_destructor(ErlNifEnv *env, void *res) {
+    UNUSED(env);
+    ZstdDCtxWithBuffer* ctx_resource = static_cast<ZstdDCtxWithBuffer*>(res);
+    ZSTD_freeDCtx(ctx_resource->dctx);
+    free(ctx_resource->out.dst);
+}
+
 int on_nif_load(ErlNifEnv* env, void** priv_data, ERL_NIF_TERM load_info)
 {
     UNUSED(load_info);
 
     ATOMS.atomError = make_atom(env, kAtomError);
     ATOMS.atomBadArg = make_atom(env, kAtomBadArg);
+    ATOMS.atomOk = make_atom(env, kAtomOk);
+    ATOMS.atomContinue = make_atom(env, kAtomContinue);
     *priv_data = nullptr;
 
     ErlNifResourceFlags flags = ErlNifResourceFlags(ERL_NIF_RT_CREATE | ERL_NIF_RT_TAKEOVER);
     COMPRESS_DICTIONARY_RES_TYPE = enif_open_resource_type(env, nullptr, "ZStandard.CompressDictionary", zstd_nif_compress_dictionary_destructor, flags, nullptr);
 
     DECOMPRESS_DICTIONARY_RES_TYPE = enif_open_resource_type(env, nullptr, "ZStandard.DecompressDictionary", zstd_nif_decompress_dictionary_destructor, flags, nullptr);
+
+    COMPRESS_CONTEXT_RES_TYPE = enif_open_resource_type(env, nullptr, "ZStandard.CompressionContext", zstd_nif_compression_context_destructor, flags, nullptr);
+    DECOMPRESS_CONTEXT_RES_TYPE = enif_open_resource_type(env, nullptr, "ZStandard.DecompressionContext", zstd_nif_decompression_context_destructor, flags, nullptr);
 
     return 0;
 }
@@ -113,6 +149,120 @@ static ERL_NIF_TERM zstd_nif_compress_using_cdict(ErlNifEnv* env, int argc, cons
     }
 
     return make_binary(env, out_buffer.get(), compressed_size);
+}
+
+static ERL_NIF_TERM zstd_nif_create_compression_context(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
+{
+    UNUSED(argc);
+    
+    unsigned int out_buffer_size;
+
+    if (!enif_get_uint(env, argv[0], &out_buffer_size)) {
+        return make_badarg(env);
+    }
+
+    if (out_buffer_size > MAX_BUFFER_SIZE) {
+        return make_badarg(env);
+    }
+
+    ZSTD_CCtx* context = ZSTD_createCCtx();
+    if (!context) {
+        return make_error(env, "unable to create context");
+    }
+
+    void* buffer = malloc(out_buffer_size);
+    if (!buffer) {
+        ZSTD_freeCCtx(context);
+        return make_error(env, "unable to create buffer");
+    }
+
+    ZstdCCtxWithBuffer* resource = static_cast<ZstdCCtxWithBuffer*>(enif_alloc_resource(COMPRESS_CONTEXT_RES_TYPE, sizeof(ZstdCCtxWithBuffer)));
+    resource->cctx = context;
+    resource->out.dst = buffer;
+    resource->out.pos = 0;
+    resource->out.size = out_buffer_size;
+    
+    ERL_NIF_TERM result = enif_make_resource(env, resource);
+
+    enif_release_resource(resource);
+    return result;
+}
+
+static ERL_NIF_TERM zstd_nif_create_decompression_context(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
+{
+    UNUSED(argc);
+    
+    unsigned int out_buffer_size;
+
+    if (!enif_get_uint(env, argv[0], &out_buffer_size)) {
+        return make_badarg(env);
+    }
+
+    if (out_buffer_size > MAX_BUFFER_SIZE) {
+        return make_badarg(env);
+    }
+
+    ZSTD_DCtx* context = ZSTD_createDCtx();
+    if (!context) {
+        return make_error(env, "unable to create context");
+    }
+
+    void* buffer = malloc(out_buffer_size);
+    if (!buffer) {
+        ZSTD_freeDCtx(context);
+        return make_error(env, "unable to create buffer");
+    }
+
+    ZstdDCtxWithBuffer* resource = static_cast<ZstdDCtxWithBuffer*>(enif_alloc_resource(DECOMPRESS_CONTEXT_RES_TYPE, sizeof(ZstdDCtxWithBuffer)));
+    resource->dctx = context;
+    resource->out.dst = buffer;
+    resource->out.pos = 0;
+    resource->out.size = out_buffer_size;
+    
+    ERL_NIF_TERM result = enif_make_resource(env, resource);
+
+    enif_release_resource(resource);
+    return result;
+}
+
+static ERL_NIF_TERM zstd_nif_select_cdict(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
+{
+    UNUSED(argc);
+    ZstdCCtxWithBuffer* ctx_resource;
+    ZSTD_CDict** dict_resource;
+
+    if(!enif_get_resource(env, argv[0], COMPRESS_CONTEXT_RES_TYPE, reinterpret_cast<void**>(&ctx_resource)) ||
+       !enif_get_resource(env, argv[1], COMPRESS_DICTIONARY_RES_TYPE, reinterpret_cast<void**>(&dict_resource))) {
+            return make_badarg(env);
+    }
+
+    size_t result = ZSTD_CCtx_refCDict(ctx_resource->cctx, *dict_resource);
+
+    if (ZSTD_isError(result)) {
+        return make_error(env, "failed to set dictionary");
+    }
+
+    return ATOMS.atomOk;
+}
+
+static ERL_NIF_TERM zstd_nif_select_ddict(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
+{
+    UNUSED(argc);
+    ZstdDCtxWithBuffer* ctx_resource;
+    ZSTD_DDict** dict_resource;
+
+    if(!enif_get_resource(env, argv[0], DECOMPRESS_CONTEXT_RES_TYPE, reinterpret_cast<void**>(&ctx_resource)) ||
+       !enif_get_resource(env, argv[1], DECOMPRESS_DICTIONARY_RES_TYPE, reinterpret_cast<void**>(&dict_resource))) {
+            return make_badarg(env);
+    }
+
+    size_t result = ZSTD_DCtx_refDDict(ctx_resource->dctx, *dict_resource);
+
+    if (ZSTD_isError(result)) {
+        return make_error(env, "failed to set dictionary");
+    }
+
+    return ATOMS.atomOk;
 }
 
 static ERL_NIF_TERM zstd_nif_decompress_using_ddict(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
@@ -241,6 +391,90 @@ static ERL_NIF_TERM zstd_nif_compress(ErlNifEnv* env, int argc, const ERL_NIF_TE
     return make_binary(env, out_buffer.get(), compressed_size);
 }
 
+static ERL_NIF_TERM zstd_nif_compress_streaming_chunk(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
+{
+    UNUSED(argc);
+
+    ZstdCCtxWithBuffer* ctx_resource;
+    ErlNifBinary bin;
+    uint64_t offset;
+
+    if (!enif_get_resource(env, argv[0], COMPRESS_CONTEXT_RES_TYPE, reinterpret_cast<void**>(&ctx_resource)) ||
+        !enif_inspect_binary(env, argv[1], &bin) ||
+        !enif_get_uint64(env, argv[2], &offset)) {
+            return make_badarg(env);
+        }
+
+    ZSTD_inBuffer in_buffer;
+    in_buffer.src = bin.data;
+    in_buffer.size = bin.size;
+    in_buffer.pos = offset;
+    ctx_resource->out.pos = 0;
+    
+
+    size_t result = ZSTD_compressStream2(
+        ctx_resource->cctx,
+        &ctx_resource->out,
+        &in_buffer,
+        ZSTD_e_flush
+    );
+
+    ERL_NIF_TERM result_chunk;
+    unsigned char* result_buffer = enif_make_new_binary(env, ctx_resource->out.pos, &result_chunk);
+    memcpy(result_buffer, ctx_resource->out.dst, ctx_resource->out.pos);
+
+    if (result == 0) {
+        return enif_make_tuple2(env, ATOMS.atomOk, result_chunk);
+    } else {
+        ERL_NIF_TERM new_offset = enif_make_uint(env, in_buffer.pos);
+        return enif_make_tuple3(env, ATOMS.atomContinue, result_chunk, new_offset);
+    }
+}
+
+static ERL_NIF_TERM zstd_nif_decompress_streaming_chunk(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
+{
+    UNUSED(argc);
+
+    ZstdDCtxWithBuffer* ctx_resource;
+    ErlNifBinary bin;
+    uint64_t offset;
+
+    if (!enif_get_resource(env, argv[0], DECOMPRESS_CONTEXT_RES_TYPE, reinterpret_cast<void**>(&ctx_resource)) ||
+        !enif_inspect_binary(env, argv[1], &bin) ||
+        !enif_get_uint64(env, argv[2], &offset)) {
+            return make_badarg(env);
+        }
+
+    ZSTD_inBuffer in_buffer;
+    in_buffer.src = bin.data;
+    in_buffer.size = bin.size;
+    in_buffer.pos = offset;
+    ctx_resource->out.pos = 0;
+    
+
+    size_t result = ZSTD_decompressStream(
+        ctx_resource->dctx,
+        &ctx_resource->out,
+        &in_buffer
+    );
+
+    ERL_NIF_TERM result_chunk;
+    unsigned char* result_buffer = enif_make_new_binary(env, ctx_resource->out.pos, &result_chunk);
+    memcpy(result_buffer, ctx_resource->out.dst, ctx_resource->out.pos);
+
+    if (result == 0 || in_buffer.pos == in_buffer.size) {
+        return enif_make_tuple2(env, ATOMS.atomOk, result_chunk);
+    } else if (result > 0) {
+        if (in_buffer.pos == offset) {
+            return make_error(env, "corrupted data");
+        }
+        ERL_NIF_TERM new_offset = enif_make_uint(env, in_buffer.pos);
+        return enif_make_tuple3(env, ATOMS.atomContinue, result_chunk, new_offset);
+    } else {
+        return make_badarg(env);
+    }
+}
+
 static ERL_NIF_TERM zstd_nif_get_dict_id_from_frame(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
 {
     UNUSED(argc);
@@ -295,6 +529,12 @@ static ErlNifFunc nif_funcs[] = {
     {"get_dict_id_from_frame", 1, zstd_nif_get_dict_id_from_frame},
     {"compress_using_cdict", 2, zstd_nif_compress_using_cdict},
     {"decompress_using_ddict", 2, zstd_nif_decompress_using_ddict},
+    {"create_compression_context", 1, zstd_nif_create_compression_context},
+    {"create_decompression_context", 1, zstd_nif_create_decompression_context},
+    {"select_cdict", 2, zstd_nif_select_cdict},
+    {"select_ddict", 2, zstd_nif_select_ddict},
+    {"compress_streaming_chunk", 3, zstd_nif_compress_streaming_chunk},
+    {"decompress_streaming_chunk", 3, zstd_nif_decompress_streaming_chunk}
 };
 
 ERL_NIF_INIT(ezstd_nif, nif_funcs, on_nif_load, NULL, NULL, on_nif_unload);

--- a/c_src/ezstd_nif.cc
+++ b/c_src/ezstd_nif.cc
@@ -426,6 +426,9 @@ static ERL_NIF_TERM zstd_nif_compress_streaming_chunk(ErlNifEnv* env, int argc, 
     if (result == 0) {
         return enif_make_tuple2(env, ATOMS.atomOk, result_chunk);
     } else {
+        if (in_buffer.pos == offset) {
+            return make_error(env, "compressor stuck");
+        }
         ERL_NIF_TERM new_offset = enif_make_uint(env, in_buffer.pos);
         return enif_make_tuple3(env, ATOMS.atomContinue, result_chunk, new_offset);
     }

--- a/c_src/ezstd_nif.h
+++ b/c_src/ezstd_nif.h
@@ -7,6 +7,9 @@ struct atoms
 {
     ERL_NIF_TERM atomError;
     ERL_NIF_TERM atomBadArg;
+    ERL_NIF_TERM atomOk;
+    ERL_NIF_TERM atomContinue;
+    ERL_NIF_TERM atomInvalidData;
 };
 
 extern atoms ATOMS;

--- a/src/ezstd_nif.erl
+++ b/src/ezstd_nif.erl
@@ -14,8 +14,13 @@
     decompress_using_ddict/2,
     get_dict_id_from_cdict/1,
     get_dict_id_from_ddict/1,
-    get_dict_id_from_frame/1
-
+    get_dict_id_from_frame/1,
+    create_compression_context/1,
+    select_cdict/2,
+    compress_streaming_chunk/3,
+    create_decompression_context/1,
+    select_ddict/2,
+    decompress_streaming_chunk/3
 ]).
 
 %% nif functions
@@ -62,4 +67,22 @@ get_dict_id_from_ddict(_DDict) ->
     ?NOT_LOADED.
 
 get_dict_id_from_frame(_Binary) ->
+    ?NOT_LOADED.
+
+create_compression_context(_BufferSize) ->
+    ?NOT_LOADED.
+
+select_cdict(_CCtx, _CDict) ->
+    ?NOT_LOADED.
+
+compress_streaming_chunk(_CCtx, _Binary, _Offset) ->
+    ?NOT_LOADED.
+
+create_decompression_context(_BufferSize) ->
+    ?NOT_LOADED.
+
+select_ddict(_DCtx, _Ddict) ->
+    ?NOT_LOADED.
+
+decompress_streaming_chunk(_DCtx, _Binary, _Offset) ->
     ?NOT_LOADED.


### PR DESCRIPTION
Add streaming support. The intended flow is:
- Call ezstd:create_compression_context to get a context
- (optional) Call ezstd:select_cdict with a dictionary and the context to select that dictionary
- Repeatedly call ezstd:compress_streaming to compress more chunks. Each one will be fully flushed when returning.

Similar process for decompression.