### PR TITLE
Allow setting a couple compression/decompression parameters

### DIFF
--- a/c_src/ezstd_nif.cc
+++ b/c_src/ezstd_nif.cc
@@ -265,6 +265,46 @@ static ERL_NIF_TERM zstd_nif_select_ddict(ErlNifEnv* env, int argc, const ERL_NI
     return ATOMS.atomOk;
 }
 
+static ERL_NIF_TERM zstd_nif_set_compression_parameter(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
+{
+    UNUSED(argc);
+
+    ZstdCCtxWithBuffer* ctx_resource;
+    ZSTD_cParameter param_id;
+    int value;
+    if(!enif_get_resource(env, argv[0], COMPRESS_CONTEXT_RES_TYPE, reinterpret_cast<void**>(&ctx_resource)) ||
+       !enif_get_int(env, argv[1], reinterpret_cast<int*>(&param_id)) ||
+       !enif_get_int(env, argv[2], &value)) {
+        return make_badarg(env);
+    }
+
+    size_t result = ZSTD_CCtx_setParameter(ctx_resource->cctx, param_id, value);
+    if (ZSTD_isError(result)) {
+        return make_badarg(env);
+    }
+    return ATOMS.atomOk;
+}
+
+static ERL_NIF_TERM zstd_nif_set_decompression_parameter(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
+{
+    UNUSED(argc);
+
+    ZstdDCtxWithBuffer* ctx_resource;
+    ZSTD_dParameter param_id;
+    int value;
+    if(!enif_get_resource(env, argv[0], DECOMPRESS_CONTEXT_RES_TYPE, reinterpret_cast<void**>(&ctx_resource)) ||
+       !enif_get_int(env, argv[1], reinterpret_cast<int*>(&param_id)) ||
+       !enif_get_int(env, argv[2], &value)) {
+        return make_badarg(env);
+    }
+
+    size_t result = ZSTD_DCtx_setParameter(ctx_resource->dctx, param_id, value);
+    if (ZSTD_isError(result)) {
+        return make_badarg(env);
+    }
+    return ATOMS.atomOk;
+}
+
 static ERL_NIF_TERM zstd_nif_decompress_using_ddict(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
 {
     UNUSED(argc);
@@ -543,6 +583,8 @@ static ErlNifFunc nif_funcs[] = {
     {"create_decompression_context", 1, zstd_nif_create_decompression_context},
     {"select_cdict", 2, zstd_nif_select_cdict},
     {"select_ddict", 2, zstd_nif_select_ddict},
+    {"set_compression_parameter", 3, zstd_nif_set_compression_parameter},
+    {"set_decompression_parameter", 3, zstd_nif_set_decompression_parameter},
     {"compress_streaming_chunk", 3, zstd_nif_compress_streaming_chunk},
     {"decompress_streaming_chunk", 3, zstd_nif_decompress_streaming_chunk}
 };

--- a/src/ezstd_nif.erl
+++ b/src/ezstd_nif.erl
@@ -17,9 +17,11 @@
     get_dict_id_from_frame/1,
     create_compression_context/1,
     select_cdict/2,
+    set_compression_parameter/3,
     compress_streaming_chunk/3,
     create_decompression_context/1,
     select_ddict/2,
+    set_decompression_parameter/3,
     decompress_streaming_chunk/3
 ]).
 
@@ -75,6 +77,9 @@ create_compression_context(_BufferSize) ->
 select_cdict(_CCtx, _CDict) ->
     ?NOT_LOADED.
 
+set_compression_parameter(_CCtx, _Param, _Value) ->
+    ?NOT_LOADED.
+
 compress_streaming_chunk(_CCtx, _Binary, _Offset) ->
     ?NOT_LOADED.
 
@@ -82,6 +87,9 @@ create_decompression_context(_BufferSize) ->
     ?NOT_LOADED.
 
 select_ddict(_DCtx, _Ddict) ->
+    ?NOT_LOADED.
+
+set_decompression_parameter(_CCtx, _Param, _Value) ->
     ?NOT_LOADED.
 
 decompress_streaming_chunk(_DCtx, _Binary, _Offset) ->

--- a/test/ezstd_test_SUITE.erl
+++ b/test/ezstd_test_SUITE.erl
@@ -47,6 +47,8 @@ roundtrip_with_streaming_compress_test(_) ->
 
   CContext = ezstd:create_compression_context(10),
   ?assertEqual(ok, ezstd:select_cdict(CContext, CDict)),
+  ?assertEqual(ok, ezstd:set_compression_parameter(CContext, zstd_c_compression_level, 5)),
+  ?assertEqual(ok, ezstd:set_compression_parameter(CContext, zstd_c_window_log, 12)),
   Plaintext = <<"contentcontentcontentcontentcontentcontentcontentcontentcontentcontentcontentcontent">>,
  
   CompressedIOList = ezstd:compress_streaming(CContext, Plaintext),
@@ -54,6 +56,7 @@ roundtrip_with_streaming_compress_test(_) ->
   
   DContext = ezstd:create_decompression_context(10),
   ?assertEqual(ok, ezstd:select_ddict(DContext, DDict)),
+  ?assertEqual(ok, ezstd:set_decompression_parameter(DContext, zstd_d_window_log_max, 15)),
 
   RehydratedIOList = ezstd:decompress_streaming(DContext, CompressedBinary),
   RehydratedBinary = erlang:iolist_to_binary(RehydratedIOList),


### PR DESCRIPTION
Apparently zstd wants to use up to 256MB of memory of lookbehind per stream. This is a lot of memory. We should be able to tune this down to get a more reasonable trade-off. Add some bindings to set compression parameters.